### PR TITLE
Add type definitions for TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+declare function assign <T, U> (target: T, source: U): T & U;
+declare function assign <T, U, V> (target: T, source1: U, source2: V): T & U & V;
+declare function assign <T, U, V, W> (target: T, source1: U, source2: V, source3: W): T & U & V & W;
+declare function assign <T, U, V, W, Q> (target: T, source1: U, source2: V, source3: W, source4: Q): T & U & V & W & Q;
+declare function assign (target: any, ...sources: any[]): any;
+
+export default assign;

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
   },
   "main": "dist/nano-assign.common.js",
   "unpkg": "dist/nano-assign.js",
+  "types": "index.d.ts",
   "cdn": "dist/nano-assign.js",
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "scripts": {
     "test": "jest && npm run lint",


### PR DESCRIPTION
Hi, egoist. This adds `index.d.ts` file with type definitions for TypeScript and include it on package's types and files.

This types are based on type definitions for Object.assign and object-assign module.
- [object-assign types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/549360d30e796ac5635e019cb276e8af9933ff71/types/object-assign/index.d.ts#L7)
- [Object.assign types](https://github.com/Microsoft/TypeScript/blob/6fd6a04f2eabcbd468b80aac270b34bad24892e4/lib/lib.es2015.core.d.ts#L286)